### PR TITLE
Fix tests failing on netns switching

### DIFF
--- a/internal/tests/ns/client.go
+++ b/internal/tests/ns/client.go
@@ -22,6 +22,7 @@ package ns
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/vishvananda/netns"
@@ -43,6 +44,9 @@ func NewClient(ns netns.NsHandle) networkservice.NetworkServiceClient {
 }
 
 func (n *nsClient) Request(ctx context.Context, request *networkservice.NetworkServiceRequest, opts ...grpc.CallOption) (*networkservice.Connection, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	curNetns, err := netns.Get()
 	if err != nil {
 		return nil, err
@@ -63,6 +67,9 @@ func (n *nsClient) Request(ctx context.Context, request *networkservice.NetworkS
 }
 
 func (n *nsClient) Close(ctx context.Context, conn *networkservice.Connection, opts ...grpc.CallOption) (*empty.Empty, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	curNetns, err := netns.Get()
 	if err != nil {
 		return nil, err

--- a/internal/tests/ns/server.go
+++ b/internal/tests/ns/server.go
@@ -20,6 +20,7 @@ package ns
 
 import (
 	"context"
+	"runtime"
 
 	"github.com/golang/protobuf/ptypes/empty"
 	"github.com/vishvananda/netns"
@@ -40,6 +41,9 @@ func NewServer(ns netns.NsHandle) networkservice.NetworkServiceServer {
 }
 
 func (n *nsServer) Request(ctx context.Context, request *networkservice.NetworkServiceRequest) (*networkservice.Connection, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	curNetns, err := netns.Get()
 	if err != nil {
 		return nil, err
@@ -60,6 +64,9 @@ func (n *nsServer) Request(ctx context.Context, request *networkservice.NetworkS
 }
 
 func (n *nsServer) Close(ctx context.Context, conn *networkservice.Connection) (*empty.Empty, error) {
+	runtime.LockOSThread()
+	defer runtime.UnlockOSThread()
+
 	curNetns, err := netns.Get()
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Fix failing Docker tests with message like this:
```
    suite_combinatronics_test.go:125: 
        	Error Trace:	suite_combinatronics_test.go:125
        	Error:      	Received unexpected error:
        	            	Link not found
        	            	unable to find interface "ns-e4dc57ba-cc6"
```
Resolves #64

Signed-off-by: Anatoly Loskutnikov <anatoly.loskutnikov@gmail.com>