### PR TITLE
fix: Use ENTRYPOINT instead of  CMD to receive os.Signal correctly

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -30,4 +30,4 @@ CMD dlv -l :40000 --headless=true --api-version=2 test -test.v .
 
 FROM ghcr.io/edwarnicke/govpp/vpp:${VPP_VERSION} as runtime
 COPY --from=build /bin/forwarder /bin/forwarder
-CMD /bin/forwarder
+ENTRYPOINT [ "/bin/forwarder" ]


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>