### PR TITLE
Block AF_PACKET bound tunnel interface from communication

### DIFF
--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -9,6 +9,8 @@ import (
 	_ "github.com/antonfisher/nested-logrus-formatter"
 	_ "github.com/edwarnicke/debug"
 	_ "github.com/edwarnicke/exechelper"
+	_ "github.com/edwarnicke/govpp/binapi/acl"
+	_ "github.com/edwarnicke/govpp/binapi/acl_types"
 	_ "github.com/edwarnicke/govpp/binapi/af_packet"
 	_ "github.com/edwarnicke/govpp/binapi/fib_types"
 	_ "github.com/edwarnicke/govpp/binapi/interface"

--- a/internal/vppinit/acl.go
+++ b/internal/vppinit/acl.go
@@ -1,0 +1,88 @@
+// Copyright (c) 2020 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppinit
+
+import (
+	"context"
+	"net"
+	"time"
+
+	"git.fd.io/govpp.git/api"
+	"github.com/edwarnicke/govpp/binapi/acl"
+	"github.com/edwarnicke/govpp/binapi/acl_types"
+	"github.com/edwarnicke/govpp/binapi/interface_types"
+	"github.com/pkg/errors"
+
+	"github.com/networkservicemesh/sdk-vpp/pkg/tools/types"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+)
+
+func denyAllACLToInterface(ctx context.Context, vppConn api.Connection, swIfIndex interface_types.InterfaceIndex) error {
+	denyAll := &acl.ACLAddReplace{
+		ACLIndex: ^uint32(0),
+		Tag:      "nsm-vppinit-denyall",
+		R: []acl_types.ACLRule{
+			{
+				IsPermit: acl_types.ACL_ACTION_API_DENY,
+				SrcPrefix: types.ToVppPrefix(&net.IPNet{
+					IP:   net.IPv4zero,
+					Mask: net.CIDRMask(0, 32),
+				}),
+			},
+			{
+				IsPermit: acl_types.ACL_ACTION_API_DENY,
+				SrcPrefix: types.ToVppPrefix(&net.IPNet{
+					IP:   net.IPv6zero,
+					Mask: net.CIDRMask(0, 128),
+				}),
+			},
+		},
+	}
+
+	now := time.Now()
+	denyAllRsp, err := acl.NewServiceClient(vppConn).ACLAddReplace(ctx, denyAll)
+	if err != nil {
+		return errors.Wrapf(err, "unable to add denyall ACL")
+	}
+
+	log.FromContext(ctx).
+		WithField("aclIndex", denyAllRsp.ACLIndex).
+		WithField("duration", time.Since(now)).
+		WithField("vppapi", "ACLAddReplace").Debug("completed")
+
+	now = time.Now()
+	interfaceACLList := &acl.ACLInterfaceSetACLList{
+		SwIfIndex: swIfIndex,
+		Count:     2,
+		NInput:    1,
+		Acls: []uint32{
+			denyAllRsp.ACLIndex,
+			denyAllRsp.ACLIndex,
+		},
+	}
+	_, err = acl.NewServiceClient(vppConn).ACLInterfaceSetACLList(ctx, interfaceACLList)
+	if err != nil {
+		return errors.Wrapf(err, "unable to add aclList ACL")
+	}
+	log.FromContext(ctx).
+		WithField("swIfIndex", interfaceACLList.SwIfIndex).
+		WithField("acls", interfaceACLList.Acls).
+		WithField("NInput", interfaceACLList.NInput).
+		WithField("duration", time.Since(now)).
+		WithField("vppapi", "ACLInterfaceSetACLList").Debug("completed")
+	return nil
+}

--- a/internal/vppinit/vppinit.go
+++ b/internal/vppinit/vppinit.go
@@ -92,6 +92,10 @@ func LinkToAfPacket(ctx context.Context, vppConn api.Connection, tunnelIP net.IP
 		return nil, err
 	}
 
+	if aclErr := denyAllACLToInterface(ctx, vppConn, swIfIndex); aclErr != nil {
+		return nil, aclErr
+	}
+
 	now := time.Now()
 	_, err = interfaces.NewServiceClient(vppConn).SwInterfaceSetFlags(ctx, &interfaces.SwInterfaceSetFlags{
 		SwIfIndex: swIfIndex,


### PR DESCRIPTION
When binding to the tunnel interface with AF_PACKET, we should *not*
respond to anything except valid tunnel packets.

vppinit does this by applying a DENYALL ACL.

Individual tunnel chain elements are then responsible for poking a 'hole'
in the DENYALL ACL for themselves.  See:

https://github.com/networkservicemesh/sdk-vpp/tree/main/pkg/networkservice/mechanisms/vxlan/vxlanacl

Signed-off-by: Ed Warnicke <hagbard@gmail.com>
