### PR TITLE
Fix kernel endpoint verifying in docker tests

### DIFF
--- a/internal/tests/suite_kernel_test.go
+++ b/internal/tests/suite_kernel_test.go
@@ -117,6 +117,9 @@ func (k *kernelVerifiableEndpoint) VerifyConnection(conn *networkservice.Connect
 	namingConn.Mechanism = &networkservice.Mechanism{
 		Cls:  cls.LOCAL,
 		Type: kernel.MECHANISM,
+		Parameters: map[string]string{
+			kernel.InterfaceNameKey: kernelmechanism.GetNameFromConnection(namingConn),
+		},
 	}
 	if err := checkKernelInterface(namingConn, conn.GetContext().GetIpContext().GetDstIPNets(), k.endpointNSHandle); err != nil {
 		return err


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/sdk-vpp/issues/254

Needed because of:
https://github.com/networkservicemesh/sdk/pull/1014
https://github.com/networkservicemesh/api/pull/108

Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>