### PR TITLE
[qfix] Increase dial timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -41,7 +41,7 @@ type Config struct {
 	ListenOn              url.URL           `default:"unix:///listen.on.socket" desc:"url to listen on" split_words:"true"`
 	MaxTokenLifetime      time.Duration     `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	LogLevel              string            `default:"INFO" desc:"Log level" split_words:"true"`
-	DialTimeout           time.Duration     `default:"50ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
+	DialTimeout           time.Duration     `default:"100ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
 	OpenTelemetryEndpoint string            `default:"otel-collector.observability.svc.cluster.local:4317" desc:"OpenTelemetry Collector Endpoint"`
 
 	TunnelIP     net.IP       `desc:"IP to use for tunnels" split_words:"true"`


### PR DESCRIPTION

`50 ms` is not enough for some cases

```
...
Feb  5 20:06:30.795[37m [TRAC] [id:21a9d757-c9c4-4737-8f3e-c64377b447db] [type:networkService] [0m(39)                                       ⎆ sdk/pkg/networkservice/common/null/nullClient.Request()
Feb  5 20:06:30.795[37m [TRAC] [id:21a9d757-c9c4-4737-8f3e-c64377b447db] [type:networkService] [0m(40)                                        ⎆ sdk/pkg/networkservice/common/dial/dialClient.Request()
Feb  5 20:06:30.846[31m [ERRO] [id:21a9d757-c9c4-4737-8f3e-c64377b447db] [type:networkService] [0m(40.1)                                          can not dial to unix:///proc/1/fd/24, err failed to dial unix:///proc/1/fd/24: context deadline exceeded. Deleting clientconn...
Feb  5 20:06:30.846[31m [ERRO] [id:21a9d757-c9c4-4737-8f3e-c64377b447db] [type:networkService] [0m(40.2)                                          failed to dial unix:///proc/1/fd/24: context deadline exceeded
...
```
Signed-off-by: Artem Glazychev <artem.glazychev@xored.com>