### PR TITLE
qfix: start vpp in tmp folder to avoid collisions with external vpp cases

### DIFF
--- a/main.go
+++ b/main.go
@@ -172,7 +172,8 @@ func main() {
 		if err = cfg.VppInit.Decode("AF_PACKET"); err != nil {
 			log.FromContext(ctx).Fatalf("VppInit.Decode error: %v", err)
 		}
-		tmpDir, err := ioutil.TempDir("", cfg.Name)
+		var tmpDir string
+		tmpDir, err = ioutil.TempDir("", cfg.Name)
 		if err != nil {
 			logrus.Fatalf("error creating tmpDir %+v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -21,6 +21,7 @@ package main
 
 import (
 	"context"
+	"io/ioutil"
 	"os"
 	"os/signal"
 	"path"
@@ -171,7 +172,11 @@ func main() {
 		if err = cfg.VppInit.Decode("AF_PACKET"); err != nil {
 			log.FromContext(ctx).Fatalf("VppInit.Decode error: %v", err)
 		}
-		vppConn, vppErrCh = vpphelper.StartAndDialContext(ctx)
+		tmpDir, err := ioutil.TempDir("", cfg.Name)
+		if err != nil {
+			logrus.Fatalf("error creating tmpDir %+v", err)
+		}
+		vppConn, vppErrCh = vpphelper.StartAndDialContext(ctx, vpphelper.WithRootDir(tmpDir))
 		exitOnErrCh(ctx, cancel, vppErrCh)
 		close(cleanupDoneCh)
 		log.FromContext(ctx).Info("local vpp is being used")


### PR DESCRIPTION
Signed-off-by: Denis Tingaikin <denis.tingajkin@xored.com>

## Motivation


Closes https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/533