### PR TITLE
Added missed grpc option

### DIFF
--- a/main.go
+++ b/main.go
@@ -227,6 +227,7 @@ func main() {
 
 	dialOptions := append(
 		tracing.WithTracingDial(),
+		grpc.WithBlock(),
 		grpc.WithDefaultCallOptions(
 			grpc.WaitForReady(true),
 			grpc.PerRPCCredentials(token.NewPerRPCCredentials(spiffejwt.TokenGeneratorFunc(source, cfg.MaxTokenLifetime)))),


### PR DESCRIPTION
### Description
`grpc.WithBlock()` was missed in this PR - https://github.com/networkservicemesh/cmd-forwarder-vpp/pull/854