### PR TITLE
Increase dial timeout

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -44,7 +44,7 @@ type Config struct {
 	MaxTokenLifetime       time.Duration     `default:"10m" desc:"maximum lifetime of tokens" split_words:"true"`
 	RegistryClientPolicies []string          `default:"etc/nsm/opa/common/.*.rego,etc/nsm/opa/registry/.*.rego,etc/nsm/opa/client/.*.rego" desc:"paths to files and directories that contain registry client policies" split_words:"true"`
 	LogLevel               string            `default:"INFO" desc:"Log level" split_words:"true"`
-	DialTimeout            time.Duration     `default:"100ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
+	DialTimeout            time.Duration     `default:"750ms" desc:"Timeout for the dial the next endpoint" split_words:"true"`
 	OpenTelemetryEndpoint  string            `default:"otel-collector.observability.svc.cluster.local:4317" desc:"OpenTelemetry Collector Endpoint"`
 	MetricsExportInterval  time.Duration     `default:"10s" desc:"interval between mertics exports" split_words:"true"`
 


### PR DESCRIPTION
Issue: https://github.com/networkservicemesh/deployments-k8s/issues/11372

We checked that for 30 clients on one node, about `500ms` dial timeout is required. Set to `750ms` here as a fallback.