### PR TITLE
Added channel complition logs

### DIFF
--- a/main.go
+++ b/main.go
@@ -337,9 +337,13 @@ func main() {
 
 	// TODO - cleaner shutdown across these channels
 	<-ctx.Done()
+	log.FromContext(ctx).Infof("Completed <-ctx.Done()")
 	<-srvErrCh
+	log.FromContext(ctx).Infof("Completed <-srvErrCh")
 	<-vppErrCh
+	log.FromContext(ctx).Infof("Completed <-vppErrCh")
 	<-cleanupDoneCh
+	log.FromContext(ctx).Infof("Completed <-cleanupDoneCh")
 }
 
 func setupDeviceMap(ctx context.Context, cfg *config.Config) map[string]string {


### PR DESCRIPTION
PR is created to investigate problem, where forwarder pod cannot be terminated in kubernates.

Logs after command to kill the pod:
```
2024-11-05T07:45:35.1873352Z Nov  5 06:41:44.157 [ERRO] [cmd:/bin/forwarder] <nil>
2024-11-05T07:45:35.1874253Z Nov  5 06:41:44.304 [INFO] [cmd:/bin/forwarder] [component:netNsMonitor] [inodeURL:inode://4/4026533101] stopping...
```

Failed job: https://github.com/networkservicemesh/integration-k8s-kind/actions/runs/11678605869/job/32518340408?pr=1039 