### PR TITLE
Add timeout for all VPP Operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ docker build .
 * `NSM_VPP_API_SOCKET`                   - filename of socket to connect to existing VPP instance.
 * `NSM_VPP_INIT`                         - type of VPP initialization. Must be AF_XDP, AF_PACKET or NONE
 * `NSM_VPP_INIT_PARAMS`                  - Configuration file path containing VPP API parameters for initialization
+* `NSM_VPP_MIN_OPERATION_TIMEOUT`        - minimum timeout for every vpp operation
 * `NSM_RESOURCE_POLL_TIMEOUT`            - device plugin polling timeout
 * `NSM_DEVICE_PLUGIN_PATH`               - path to the device plugin directory
 * `NSM_POD_RESOURCES_PATH`               - path to the pod resources directory

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -52,11 +52,12 @@ type Config struct {
 	PrometheusListenOn            string            `default:":8081" desc:"Prometheus URL to ListenAndServe" split_words:"true"`
 	PrometheusServerHeaderTimeout time.Duration     `default:"5s" desc:"Timeout for how long the Prometheus server waits for complete request headers from the client" split_words:"true"`
 
-	TunnelIP      net.IP       `desc:"IP to use for tunnels" split_words:"true"`
-	VxlanPort     uint16       `default:"0" desc:"VXLAN port to use" split_words:"true"`
-	VppAPISocket  string       `default:"/var/run/vpp/external/vpp-api.sock" desc:"filename of socket to connect to existing VPP instance.  If empty a VPP instance is run in forwarder" split_words:"true"`
-	VppInit       vppinit.Func `default:"AF_PACKET" desc:"type of VPP initialization. Must be AF_XDP, AF_PACKET or NONE" split_words:"true"`
-	VppInitParams string       `desc:"Configuration file path containing VPP API parameters for initialization" split_words:"true"`
+	TunnelIP               net.IP        `desc:"IP to use for tunnels" split_words:"true"`
+	VxlanPort              uint16        `default:"0" desc:"VXLAN port to use" split_words:"true"`
+	VppAPISocket           string        `default:"/var/run/vpp/external/vpp-api.sock" desc:"filename of socket to connect to existing VPP instance.  If empty a VPP instance is run in forwarder" split_words:"true"`
+	VppInit                vppinit.Func  `default:"AF_PACKET" desc:"type of VPP initialization. Must be AF_XDP, AF_PACKET or NONE" split_words:"true"`
+	VppInitParams          string        `desc:"Configuration file path containing VPP API parameters for initialization" split_words:"true"`
+	VPPMinOperationTimeout time.Duration `default:"2s" desc:"minimum timeout for every vpp operation" split_words:"true"`
 
 	ResourcePollTimeout time.Duration `default:"30s" desc:"device plugin polling timeout" split_words:"true"`
 	DevicePluginPath    string        `default:"/var/lib/kubelet/device-plugins/" desc:"path to the device plugin directory" split_words:"true"`

--- a/internal/imports/imports_linux.go
+++ b/internal/imports/imports_linux.go
@@ -80,6 +80,7 @@ import (
 	_ "github.com/networkservicemesh/sdk/pkg/registry/common/sendfd"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/core/adapters"
 	_ "github.com/networkservicemesh/sdk/pkg/registry/core/chain"
+	_ "github.com/networkservicemesh/sdk/pkg/tools/extend"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/grpcutils"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log"
 	_ "github.com/networkservicemesh/sdk/pkg/tools/log/logruslogger"

--- a/internal/tests/suite_ipsec_test.go
+++ b/internal/tests/suite_ipsec_test.go
@@ -24,9 +24,8 @@ import (
 	"context"
 	"net"
 
+	"go.fd.io/govpp/api"
 	"google.golang.org/grpc"
-
-	"github.com/networkservicemesh/vpphelper"
 
 	"github.com/networkservicemesh/api/pkg/api/networkservice"
 	ipsecapi "github.com/networkservicemesh/api/pkg/api/networkservice/mechanisms/ipsec"
@@ -47,14 +46,14 @@ import (
 
 type ipsecVerifiableEndpoint struct {
 	ctx     context.Context
-	vppConn vpphelper.Connection
+	vppConn api.Connection
 	endpoint.Endpoint
 }
 
 func newIpsecVerifiableEndpoint(ctx context.Context,
 	prefix1, prefix2 *net.IPNet,
 	tokenGenerator token.GeneratorFunc,
-	vppConn vpphelper.Connection) verifiableEndpoint {
+	vppConn api.Connection) verifiableEndpoint {
 	rv := &ipsecVerifiableEndpoint{
 		ctx:     ctx,
 		vppConn: vppConn,
@@ -94,14 +93,14 @@ func (v *ipsecVerifiableEndpoint) VerifyClose(_ *networkservice.Connection) erro
 
 type ipsecVerifiableClient struct {
 	ctx     context.Context
-	vppConn vpphelper.Connection
+	vppConn api.Connection
 	networkservice.NetworkServiceClient
 }
 
 func newIpsecVerifiableClient(
 	ctx context.Context,
 	sutCC grpc.ClientConnInterface,
-	vppConn vpphelper.Connection,
+	vppConn api.Connection,
 ) verifiableClient {
 	return &ipsecVerifiableClient{
 		ctx:     ctx,

--- a/internal/tests/suite_memif_test.go
+++ b/internal/tests/suite_memif_test.go
@@ -29,8 +29,6 @@ import (
 	"go.fd.io/govpp/api"
 	"go.fd.io/govpp/binapi/vlib"
 
-	"github.com/networkservicemesh/vpphelper"
-
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/common/mechanisms/sendfd"
 	"github.com/networkservicemesh/sdk/pkg/networkservice/core/chain"
@@ -63,7 +61,7 @@ type memifVerifiableEndpoint struct {
 func newMemifVerifiableEndpoint(ctx context.Context,
 	prefix1, prefix2 *net.IPNet,
 	tokenGenerator token.GeneratorFunc,
-	vppConn vpphelper.Connection,
+	vppConn api.Connection,
 ) verifiableEndpoint {
 	return &memifVerifiableEndpoint{
 		ctx:     ctx,
@@ -110,7 +108,7 @@ type memifVerifiableClient struct {
 	networkservice.NetworkServiceClient
 }
 
-func newMemifVerifiableClient(ctx context.Context, sutCC grpc.ClientConnInterface, vppConn vpphelper.Connection) verifiableClient {
+func newMemifVerifiableClient(ctx context.Context, sutCC grpc.ClientConnInterface, vppConn api.Connection) verifiableClient {
 	rv := &memifVerifiableClient{
 		ctx:     ctx,
 		vppConn: vppConn,

--- a/internal/tests/suite_memif_test.go
+++ b/internal/tests/suite_memif_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Cisco and/or its affiliates.
+// Copyright (c) 2020-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/tests/suite_setup_test.go
+++ b/internal/tests/suite_setup_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Cisco and/or its affiliates.
+// Copyright (c) 2020-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/tests/suite_setup_test.go
+++ b/internal/tests/suite_setup_test.go
@@ -32,6 +32,7 @@ import (
 	"github.com/sirupsen/logrus"
 	"github.com/spiffe/go-spiffe/v2/spiffetls/tlsconfig"
 	"github.com/spiffe/go-spiffe/v2/workloadapi"
+	"go.fd.io/govpp/api"
 	"go.fd.io/govpp/binapi/vpe"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials"
@@ -204,7 +205,7 @@ func (f *ForwarderTestSuite) SetupSuite() {
 	// ********************************************************************************
 }
 
-func (f *ForwarderTestSuite) createVpp(ctx context.Context, name string) (vppConn vpphelper.Connection, vppRoot string, errCh <-chan error) {
+func (f *ForwarderTestSuite) createVpp(ctx context.Context, name string) (vppConn api.Connection, vppRoot string, errCh <-chan error) {
 	now := time.Now()
 	var err error
 	vppRoot, err = os.MkdirTemp("", fmt.Sprintf("%s-", name))

--- a/internal/tests/suite_test.go
+++ b/internal/tests/suite_test.go
@@ -25,9 +25,8 @@ import (
 	"github.com/spiffe/go-spiffe/v2/bundle/x509bundle"
 	"github.com/spiffe/go-spiffe/v2/svid/x509svid"
 	"github.com/stretchr/testify/suite"
+	"go.fd.io/govpp/api"
 	"google.golang.org/grpc"
-
-	"github.com/networkservicemesh/vpphelper"
 
 	"github.com/networkservicemesh/api/pkg/api/registry"
 
@@ -51,12 +50,12 @@ type ForwarderTestSuite struct {
 	x509bundle x509bundle.Source
 
 	// vppServer stuff
-	vppServerConn  vpphelper.Connection
+	vppServerConn  api.Connection
 	vppServerRoot  string
 	vppServerErrCh <-chan error
 
 	// vppClient stuff
-	vppClientConn  vpphelper.Connection
+	vppClientConn  api.Connection
 	vppClientRoot  string
 	vppClientErrCh <-chan error
 

--- a/internal/tests/suite_test.go
+++ b/internal/tests/suite_test.go
@@ -1,4 +1,4 @@
-// Copyright (c) 2020-2023 Cisco and/or its affiliates.
+// Copyright (c) 2020-2024 Cisco and/or its affiliates.
 //
 // SPDX-License-Identifier: Apache-2.0
 //

--- a/internal/tests/suite_wireguard_test.go
+++ b/internal/tests/suite_wireguard_test.go
@@ -24,9 +24,8 @@ import (
 	"context"
 	"net"
 
+	"go.fd.io/govpp/api"
 	"google.golang.org/grpc"
-
-	"github.com/networkservicemesh/vpphelper"
 
 	"github.com/networkservicemesh/sdk/pkg/networkservice/chains/client"
 
@@ -48,14 +47,14 @@ import (
 
 type wireguardVerifiableEndpoint struct {
 	ctx     context.Context
-	vppConn vpphelper.Connection
+	vppConn api.Connection
 	endpoint.Endpoint
 }
 
 func newWireguardVerifiableEndpoint(ctx context.Context,
 	prefix1, prefix2 *net.IPNet,
 	tokenGenerator token.GeneratorFunc,
-	vppConn vpphelper.Connection) verifiableEndpoint {
+	vppConn api.Connection) verifiableEndpoint {
 	rv := &wireguardVerifiableEndpoint{
 		ctx:     ctx,
 		vppConn: vppConn,
@@ -95,14 +94,14 @@ func (v *wireguardVerifiableEndpoint) VerifyClose(_ *networkservice.Connection) 
 
 type wireguardVerifiableClient struct {
 	ctx     context.Context
-	vppConn vpphelper.Connection
+	vppConn api.Connection
 	networkservice.NetworkServiceClient
 }
 
 func newWireguardVerifiableClient(
 	ctx context.Context,
 	sutCC grpc.ClientConnInterface,
-	vppConn vpphelper.Connection,
+	vppConn api.Connection,
 ) verifiableClient {
 	return &wireguardVerifiableClient{
 		ctx:     ctx,

--- a/internal/vppinit/safevppconn.go
+++ b/internal/vppinit/safevppconn.go
@@ -1,0 +1,60 @@
+// Copyright (c) 2024 Cisco and/or its affiliates.
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at:
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package vppinit
+
+import (
+	"context"
+	"time"
+
+	"github.com/networkservicemesh/sdk/pkg/tools/extend"
+	"github.com/networkservicemesh/sdk/pkg/tools/log"
+	"go.fd.io/govpp/api"
+)
+
+type safeVPPConnection struct {
+	api.Connection
+	contextTimeout time.Duration
+}
+
+func NewSafeVPPConnection(vppConn api.Connection, contextTimeout time.Duration) api.Connection {
+	return &safeVPPConnection{
+		Connection:     vppConn,
+		contextTimeout: contextTimeout,
+	}
+}
+
+func (c *safeVPPConnection) Invoke(ctx context.Context, req api.Message, reply api.Message) error {
+	ctx, cancel := c.ToSafeContext(ctx)
+	err := c.Connection.Invoke(ctx, req, reply)
+	cancel()
+	return err
+}
+
+func (c *safeVPPConnection) ToSafeContext(ctx context.Context) (context.Context, func()) {
+	deadline, ok := ctx.Deadline()
+	if !ok {
+		return ctx, func() {}
+	}
+
+	minDeadline := time.Now().Add(c.contextTimeout)
+	if minDeadline.After(deadline) {
+		deadline = minDeadline
+		log.FromContext(ctx).Infof("Context deadline has been increased due to important request(s)")
+	}
+	postponedCtx, cancel := context.WithDeadline(context.Background(), deadline)
+	return extend.WithValuesFromContext(postponedCtx, ctx), cancel
+}

--- a/internal/vppinit/safevppconn.go
+++ b/internal/vppinit/safevppconn.go
@@ -20,9 +20,10 @@ import (
 	"context"
 	"time"
 
+	"go.fd.io/govpp/api"
+
 	"github.com/networkservicemesh/sdk/pkg/tools/extend"
 	"github.com/networkservicemesh/sdk/pkg/tools/log"
-	"go.fd.io/govpp/api"
 )
 
 type safeVPPConnection struct {
@@ -30,6 +31,7 @@ type safeVPPConnection struct {
 	contextTimeout time.Duration
 }
 
+// NewSafeVPPConnection - creates a wrapper for vpp connection that uses extended context timeout for all operations
 func NewSafeVPPConnection(vppConn api.Connection, contextTimeout time.Duration) api.Connection {
 	return &safeVPPConnection{
 		Connection:     vppConn,
@@ -37,7 +39,7 @@ func NewSafeVPPConnection(vppConn api.Connection, contextTimeout time.Duration) 
 	}
 }
 
-func (c *safeVPPConnection) Invoke(ctx context.Context, req api.Message, reply api.Message) error {
+func (c *safeVPPConnection) Invoke(ctx context.Context, req, reply api.Message) error {
 	ctx, cancel := c.ToSafeContext(ctx)
 	err := c.Connection.Invoke(ctx, req, reply)
 	cancel()

--- a/main.go
+++ b/main.go
@@ -72,6 +72,8 @@ import (
 	"github.com/networkservicemesh/cmd-forwarder-vpp/internal/devicecfg"
 	"github.com/networkservicemesh/cmd-forwarder-vpp/internal/vppinit"
 	"github.com/networkservicemesh/cmd-forwarder-vpp/internal/xconnectns"
+
+	"go.fd.io/govpp/api"
 )
 
 func main() {
@@ -174,7 +176,7 @@ func main() {
 	// ********************************************************************************
 	now = time.Now()
 
-	var vppConn vpphelper.Connection
+	var vppConn api.Connection
 	var vppErrCh <-chan error
 	var metricsOpts []metrics.Option
 	cleanupDoneCh := make(chan struct{})
@@ -201,6 +203,8 @@ func main() {
 		close(cleanupDoneCh)
 		log.FromContext(ctx).Info("local vpp is being used")
 	}
+
+	vppConn = vppinit.NewSafeVPPConnection(vppConn, cfg.VPPMinOperationTimeout)
 
 	log.FromContext(ctx).WithField("duration", time.Since(now)).Info("completed phase 2: run vpp and get a connection to it")
 


### PR DESCRIPTION
## Description
Add a default `2s` timeout for all `vpp` operations so we always have enough time to cleanup `vpp` resources.

## Issue
https://github.com/networkservicemesh/cmd-forwarder-vpp/issues/1133