### PR TITLE
Support custom certificates in metrics server

### DIFF
--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -50,6 +50,10 @@ type Config struct {
 	PprofEnabled                  bool              `default:"false" desc:"is pprof enabled" split_words:"true"`
 	PprofListenOn                 string            `default:"localhost:6060" desc:"pprof URL to ListenAndServe" split_words:"true"`
 	PrometheusListenOn            string            `default:":8081" desc:"Prometheus URL to ListenAndServe" split_words:"true"`
+	PrometheusCAFile              string            `default:"" desc:"Path to the CA file for the Prometheus server (by default the authentication will happen via TLS instead of mTLS)" split_words:"true"`
+	PrometheusKeyFile             string            `default:"" desc:"Path to the key file for the Prometheus server (by default it uses a SPIRE generated one)" split_words:"true"`
+	PrometheusCertFile            string            `default:"" desc:"Path to the certificate file for the Prometheus server (by default it uses a SPIRE generated one)" split_words:"true"`
+	PrometheusMonitorCertificate  bool              `default:"false" desc:"defines whether the custom certificate for Prometheus should be watched for updates" split_words:"true"`
 	PrometheusServerHeaderTimeout time.Duration     `default:"5s" desc:"Timeout for how long the Prometheus server waits for complete request headers from the client" split_words:"true"`
 
 	TunnelIP               net.IP        `desc:"IP to use for tunnels" split_words:"true"`

--- a/main.go
+++ b/main.go
@@ -161,7 +161,13 @@ func main() {
 	// Configure Prometheus
 	// ********************************************************************************
 	if prometheus.IsEnabled() {
-		go prometheus.ListenAndServe(ctx, cfg.PrometheusListenOn, cfg.PrometheusServerHeaderTimeout, cancel)
+		metricServer := prometheus.NewServer(
+			cfg.PrometheusListenOn,
+			prometheus.WithCustomCert(cfg.PrometheusCertFile, cfg.PrometheusKeyFile),
+			prometheus.WithCustomCA(cfg.PrometheusCAFile),
+			prometheus.WithHeaderTimeout(cfg.PrometheusServerHeaderTimeout),
+			prometheus.WithCertificateMonitoring(cfg.PrometheusMonitorCertificate))
+		go metricServer.ListenAndServe(ctx, cancel)
 	}
 
 	// ********************************************************************************


### PR DESCRIPTION
<!--- Put an `x` in all the boxes that this PR applies -->

## Description
<!--- Provide a general summary of your changes in the Title above -->
This PR introduces an option to configure custom certificates for the Prometheus metrics server. Additionally, it includes support for automatic certificate renewal to ensure the server remains operational with valid certificates.

## Issue link
<!--- Please link to the issue here. -->
https://github.com/networkservicemesh/sdk/issues/1652

## How Has This Been Tested?
<!--- Provide information on how these changes are testing -->
- [ ] Added unit testing to cover
- [X] Tested manually
- [X] Tested by integration testing
- [ ] Have not tested

<!--- Add additional comments about testing if needed. -->

## Types of changes
<!--- What types of changes does your code introduce -->
- [ ] Bug fix
- [X] New functionality
- [ ] Documentation
- [ ] Refactoring
- [ ] CI