### PR TITLE
New delve version (1.23.1)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV CGO_ENABLED=0
 ENV GOBIN=/bin
 ARG BUILDARCH=amd64
 RUN rm -r /etc/vpp
-RUN go install github.com/go-delve/delve/cmd/dlv@v1.21.0
+RUN go install github.com/go-delve/delve/cmd/dlv@v1.23.1
 RUN go install github.com/grpc-ecosystem/grpc-health-probe@v0.4.25
 ADD https://github.com/spiffe/spire/releases/download/v1.8.0/spire-1.8.0-linux-${BUILDARCH}-musl.tar.gz .
 RUN tar xzvf spire-1.8.0-linux-${BUILDARCH}-musl.tar.gz -C /bin --strip=2 spire-1.8.0/bin/spire-server spire-1.8.0/bin/spire-agent


### PR DESCRIPTION
Delve 1.21.1 is no longer works with go 1.23

Signed-off-by: Lajos Katona <lajos.katona@est.tech>
